### PR TITLE
Change to URL of the GDS distribution

### DIFF
--- a/advanced/existing-vpc-neo4j.template.yaml
+++ b/advanced/existing-vpc-neo4j.template.yaml
@@ -261,8 +261,8 @@ Resources:
 
             - "if [[ \"$graphDataScienceVersion\" != None ]]; then\n"
             - "  echo Installing Graph Data Science...\n"
-            - "  curl \"https://s3-eu-west-1.amazonaws.com/com.neo4j.graphalgorithms.dist/graph-data-science/neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\" -o neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
-            - "  unzip neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
+            - "  curl \"https://graphdatascience.ninja/neo4j-graph-data-science-${graphDataScienceVersion}.zip\" -o neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
+            - "  unzip neo4j-graph-data-science-${graphDataScienceVersion}.zip\n"
             - "  mv neo4j-graph-data-science-${graphDataScienceVersion}.jar /var/lib/neo4j/plugins\n"
             - "fi\n"
 

--- a/marketplace/neo4j.template.yaml
+++ b/marketplace/neo4j.template.yaml
@@ -259,8 +259,8 @@ Resources:
 
             - "if [[ \"$graphDataScienceVersion\" != None ]]; then\n"
             - "  echo Installing Graph Data Science...\n"
-            - "  curl \"https://s3-eu-west-1.amazonaws.com/com.neo4j.graphalgorithms.dist/graph-data-science/neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\" -o neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
-            - "  unzip neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
+            - "  curl \"https://graphdatascience.ninja/neo4j-graph-data-science-${graphDataScienceVersion}.zip\" -o neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
+            - "  unzip neo4j-graph-data-science-${graphDataScienceVersion}.zip\n"
             - "  mv neo4j-graph-data-science-${graphDataScienceVersion}.jar /var/lib/neo4j/plugins\n"
             - "fi\n"
 

--- a/simple/neo4j.template.yaml
+++ b/simple/neo4j.template.yaml
@@ -248,8 +248,8 @@ Resources:
 
             - "if [[ \"$graphDataScienceVersion\" != None ]]; then\n"
             - "  echo Installing Graph Data Science...\n"
-            - "  curl \"https://s3-eu-west-1.amazonaws.com/com.neo4j.graphalgorithms.dist/graph-data-science/neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\" -o neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
-            - "  unzip neo4j-graph-data-science-${graphDataScienceVersion}-standalone.zip\n"
+            - "  curl \"https://graphdatascience.ninja/neo4j-graph-data-science-${graphDataScienceVersion}.zip\" -o neo4j-graph-data-science-${graphDataScienceVersion}.zip\n"
+            - "  unzip neo4j-graph-data-science-${graphDataScienceVersion}.zip\n"
             - "  mv neo4j-graph-data-science-${graphDataScienceVersion}.jar /var/lib/neo4j/plugins\n"
             - "fi\n"
 


### PR DESCRIPTION
In order to comply with the sanctions against Russia,
we are moving the GDS artifacts to a new bucket that sits
behind Cloudflare and Route53 with a new domain.

Unfortunately, we cannot configure redirects from the current S3
bucket, because redirects only apply if the bucket is configured
to use static website hosting, but we used the direct object URLs.
Regardless of bucket configuration, using the direct object URL
on a public object will not issue a redirect.
