### PR TITLE
fix: move Neo4jInternetGateway dependencies to Neo4jInternetGatewayAttachment

### DIFF
--- a/marketplace/neo4j-community/neo4j.template.yaml
+++ b/marketplace/neo4j-community/neo4j.template.yaml
@@ -104,6 +104,7 @@ Resources:
 
   Neo4jRoute:
     Type: AWS::EC2::Route
+    DependsOn: Neo4jInternetGatewayAttachment
     Properties:
       GatewayId: !Ref Neo4jInternetGateway
       RouteTableId: !Ref Neo4jRouteTable

--- a/marketplace/neo4j-enterprise/neo4j.template.yaml
+++ b/marketplace/neo4j-enterprise/neo4j.template.yaml
@@ -258,6 +258,7 @@ Resources:
 
   Neo4jRoute:
     Type: AWS::EC2::Route
+    DependsOn: Neo4jInternetGatewayAttachment
     Properties:
       GatewayId: !Ref Neo4jInternetGateway
       RouteTableId: !Ref Neo4jRouteTable
@@ -299,7 +300,7 @@ Resources:
       VpcId: !Ref Neo4jVPC
 
   Neo4jNetworkLoadBalancer:
-    DependsOn: Neo4jInternetGateway
+    DependsOn: Neo4jInternetGatewayAttachment
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       IpAddressType: ipv4


### PR DESCRIPTION
Only tested with the entreprise stack.

This fix is required, the stack is no longer deploying without it.