### PR TITLE
changed template to use Launch Template instead of the now deprecated Launch Configuration

### DIFF
--- a/marketplace/neo4j-enterprise/neo4j.template.yaml
+++ b/marketplace/neo4j-enterprise/neo4j.template.yaml
@@ -391,247 +391,246 @@ Resources:
         Count: !Ref NumberOfServers
         Timeout: PT12M
     Properties:
-      AvailabilityZones: !If [CreateCluster, [!Select [ 0, Fn::GetAZs: !Ref 'AWS::Region' ] , !Select [ 1, Fn::GetAZs: !Ref 'AWS::Region' ] , !Select [ 2, Fn::GetAZs: !Ref 'AWS::Region' ]],[!Select [ 0, Fn::GetAZs: !Ref 'AWS::Region' ]]]
-      LaunchConfigurationName:
-        Ref: Neo4jLaunchConfiguration
+      VPCZoneIdentifier: !If [CreateCluster, [!Ref Neo4jSubnet1, !Ref Neo4jSubnet2, !Ref Neo4jSubnet3], [!Ref Neo4jSubnet1]]
       MinSize: !Ref NumberOfServers
       MaxSize: !Ref NumberOfServers
-      VPCZoneIdentifier: !If [CreateCluster, [!Ref Neo4jSubnet1,!Ref Neo4jSubnet2,!Ref Neo4jSubnet3], [!Ref Neo4jSubnet1]]
+      DesiredCapacity: !Ref NumberOfServers
       TargetGroupARNs:
-        - Ref: Neo4jHTTPTargetGroup
-        - Ref: Neo4jBoltTargetGroup
-      DesiredCapacity:
-        !Ref NumberOfServers
+        - !Ref Neo4jHTTPTargetGroup
+        - !Ref Neo4jBoltTargetGroup
       Tags:
         - Key: StackID
-          Value: !Ref 'AWS::StackId'
+          Value: !Ref AWS::StackId
           PropagateAtLaunch: true
         - Key: Name
-          Value: !Ref 'AWS::StackName'
+          Value: !Ref AWS::StackName
           PropagateAtLaunch: true
+      MixedInstancesPolicy:
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            LaunchTemplateId: !Ref Neo4jLaunchTemplate
+            Version: "1"
 
-  Neo4jLaunchConfiguration:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  Neo4jLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      ImageId: !FindInMap
-        - Neo4j
-        - !Ref 'AWS::Region'
-        - BYOL
-      InstanceType:
-        Ref: InstanceType
-      SecurityGroups:
-        - Ref: Neo4jExternalSecurityGroup
-        - Ref: Neo4jInternalSecurityGroup
-      EbsOptimized: true
-      IamInstanceProfile:
-        Ref: Neo4jInstanceProfile
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize:
-              Ref: DiskSize
-            VolumeType: gp3
-            Encrypted: true
-      UserData:
-        Fn::Base64:
-          !Join
-          - ''
-          - - "#!/bin/bash\n"
-            - "set -euo pipefail\n"
-            - "echo Running startup script...\n"
+      LaunchTemplateName: !Sub "${AWS::StackName}-Neo4jLT"
+      VersionDescription: "Initial version"
+      LaunchTemplateData:
+        ImageId: !FindInMap [Neo4j, !Ref 'AWS::Region', BYOL]
+        InstanceType: !Ref InstanceType
+        SecurityGroupIds:
+          - !Ref Neo4jExternalSecurityGroup
+          - !Ref Neo4jInternalSecurityGroup
+        EbsOptimized: true
+        IamInstanceProfile:
+          Name: !Ref Neo4jInstanceProfile
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              VolumeSize: !Ref DiskSize
+              VolumeType: gp3
+              Encrypted: true
+        UserData:
+          Fn::Base64: 
+            !Join
+            - ''
+            - - "#!/bin/bash\n"
+              - "set -euo pipefail\n"
+              - "echo Running startup script...\n"
 
-            - "LicenseType="
-            - Ref: Neo4jLicenseType
-            - "\n"
+              - "LicenseType="
+              - Ref: Neo4jLicenseType
+              - "\n"
 
-            - "installGraphDataScience="
-            - Ref: InstallGraphDataScience
-            - "\n"
+              - "installGraphDataScience="
+              - Ref: InstallGraphDataScience
+              - "\n"
 
-            - "graphDataScienceLicenseKey="
-            - Ref: GraphDataScienceLicenseKey
-            - "\n"
+              - "graphDataScienceLicenseKey="
+              - Ref: GraphDataScienceLicenseKey
+              - "\n"
 
-            - "installBloom="
-            - Ref: InstallBloom
-            - "\n"
+              - "installBloom="
+              - Ref: InstallBloom
+              - "\n"
 
-            - "bloomLicenseKey="
-            - Ref: BloomLicenseKey
-            - "\n"
+              - "bloomLicenseKey="
+              - Ref: BloomLicenseKey
+              - "\n"
 
-            - "password=\""
-            - Ref: Password
-            - "\"\n"
+              - "password=\""
+              - Ref: Password
+              - "\"\n"
 
-            - "nodeCount="
-            - Ref: NumberOfServers
-            - "\n"
+              - "nodeCount="
+              - Ref: NumberOfServers
+              - "\n"
 
-            - "loadBalancerDNSName="
-            - Fn::GetAtt: [Neo4jNetworkLoadBalancer,DNSName]
-            - "\n"
+              - "loadBalancerDNSName="
+              - Fn::GetAtt: [Neo4jNetworkLoadBalancer,DNSName]
+              - "\n"
 
-            - "stackName="
-            - Ref: AWS::StackName
-            - "\n"
+              - "stackName="
+              - Ref: AWS::StackName
+              - "\n"
 
-            - "region="
-            - Ref: AWS::Region
-            - "\n"
+              - "region="
+              - Ref: AWS::Region
+              - "\n"
 
-            - "install_neo4j_from_yum() {\n"
-            - "  echo \"Installing Graph Database...\"\n"
-            - "  export NEO4J_ACCEPT_LICENSE_AGREEMENT=yes\n"
-            - "  if [[ \"$LicenseType\" == \"Evaluation\" ]]; then\n"
-            - "    export NEO4J_ACCEPT_LICENSE_AGREEMENT=eval\n"
-            - "  fi\n"
-            - "  ASG_NAME=$(aws --region $region cloudformation describe-stack-resources --stack-name $stackName --query 'StackResources[?ResourceType==`AWS::AutoScaling::AutoScalingGroup` && LogicalResourceId==`Neo4jAutoScalingGroup`].PhysicalResourceId' --output text)\n"
-            - "  NEO4J_VERSION_ASG_TAG=$(aws --region $region autoscaling describe-auto-scaling-groups --auto-scaling-group-names $ASG_NAME --query 'AutoScalingGroups[0].Tags[?Key==`NEO4J_VERSION`].Value' --output text)\n"
-            - "  if [[ ! -z $NEO4J_VERSION_ASG_TAG ]]; then\n"
-            - "    echo \"Found NEO4J_VERSION_ASG_TAG Tag on AutoScalingGroup $ASG_NAME: NEO4J_VERSION_ASG_TAG=$NEO4J_VERSION_ASG_TAG\"\n"
-            - "    PACKAGE_VERSION=$NEO4J_VERSION_ASG_TAG\n"
-            - "    local -r NEO4J_YUM_PACKAGE=\"neo4j-enterprise-$PACKAGE_VERSION\"\n"
-            - "  else\n"
-            - "    PACKAGE_VERSION=$(curl --fail http://versions.neo4j-templates.com/target.json | jq -r '.aws.\"5\"' || echo \"\")\n"
-            - "    if [[ ! -z $PACKAGE_VERSION && $PACKAGE_VERSION != \"null\" ]]; then\n"
-            - "      echo \"Found PACKAGE_VERSION from http://versions.neo4j-templates.com : PACKAGE_VERSION=$PACKAGE_VERSION\"\n"
-            - "      local -r NEO4J_YUM_PACKAGE=\"neo4j-enterprise-$PACKAGE_VERSION\"\n"
-            - "    else\n"
-            - "      echo 'Failed to resolve Neo4j version from http://versions.neo4j-templates.com, using PACKAGE_VERSION=latest'\n"
-            - "      PACKAGE_VERSION=\"latest\"\n"
-            - "      local -r NEO4J_YUM_PACKAGE='neo4j-enterprise'\n"
-            - "    fi\n"
-            - "  fi\n"
-            - "  yum -y install \"${NEO4J_YUM_PACKAGE}\"\n"
-            - "  yum update -y aws-cfn-bootstrap\n"
-            - "  systemctl enable neo4j\n"
-            - "  if [[ \"$PACKAGE_VERSION\" == \"latest\" ]]; then\n"
-            - "    PACKAGE_VERSION=$(/usr/share/neo4j/bin/neo4j --version)\n"
-            - "  fi\n"
-            - "}\n"
+              - "install_neo4j_from_yum() {\n"
+              - "  echo \"Installing Graph Database...\"\n"
+              - "  export NEO4J_ACCEPT_LICENSE_AGREEMENT=yes\n"
+              - "  if [[ \"$LicenseType\" == \"Evaluation\" ]]; then\n"
+              - "    export NEO4J_ACCEPT_LICENSE_AGREEMENT=eval\n"
+              - "  fi\n"
+              - "  ASG_NAME=$(aws --region $region cloudformation describe-stack-resources --stack-name $stackName --query 'StackResources[?ResourceType==`AWS::AutoScaling::AutoScalingGroup` && LogicalResourceId==`Neo4jAutoScalingGroup`].PhysicalResourceId' --output text)\n"
+              - "  NEO4J_VERSION_ASG_TAG=$(aws --region $region autoscaling describe-auto-scaling-groups --auto-scaling-group-names $ASG_NAME --query 'AutoScalingGroups[0].Tags[?Key==`NEO4J_VERSION`].Value' --output text)\n"
+              - "  if [[ ! -z $NEO4J_VERSION_ASG_TAG ]]; then\n"
+              - "    echo \"Found NEO4J_VERSION_ASG_TAG Tag on AutoScalingGroup $ASG_NAME: NEO4J_VERSION_ASG_TAG=$NEO4J_VERSION_ASG_TAG\"\n"
+              - "    PACKAGE_VERSION=$NEO4J_VERSION_ASG_TAG\n"
+              - "    local -r NEO4J_YUM_PACKAGE=\"neo4j-enterprise-$PACKAGE_VERSION\"\n"
+              - "  else\n"
+              - "    PACKAGE_VERSION=$(curl --fail http://versions.neo4j-templates.com/target.json | jq -r '.aws.\"5\"' || echo \"\")\n"
+              - "    if [[ ! -z $PACKAGE_VERSION && $PACKAGE_VERSION != \"null\" ]]; then\n"
+              - "      echo \"Found PACKAGE_VERSION from http://versions.neo4j-templates.com : PACKAGE_VERSION=$PACKAGE_VERSION\"\n"
+              - "      local -r NEO4J_YUM_PACKAGE=\"neo4j-enterprise-$PACKAGE_VERSION\"\n"
+              - "    else\n"
+              - "      echo 'Failed to resolve Neo4j version from http://versions.neo4j-templates.com, using PACKAGE_VERSION=latest'\n"
+              - "      PACKAGE_VERSION=\"latest\"\n"
+              - "      local -r NEO4J_YUM_PACKAGE='neo4j-enterprise'\n"
+              - "    fi\n"
+              - "  fi\n"
+              - "  yum -y install \"${NEO4J_YUM_PACKAGE}\"\n"
+              - "  yum update -y aws-cfn-bootstrap\n"
+              - "  systemctl enable neo4j\n"
+              - "  if [[ \"$PACKAGE_VERSION\" == \"latest\" ]]; then\n"
+              - "    PACKAGE_VERSION=$(/usr/share/neo4j/bin/neo4j --version)\n"
+              - "  fi\n"
+              - "}\n"
 
-            - "install_apoc_plugin() {\n"
-            - "  echo \"Installing APOC...\"\n"
-            - "  mv /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins\n"
-            - "}\n"
+              - "install_apoc_plugin() {\n"
+              - "  echo \"Installing APOC...\"\n"
+              - "  mv /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins\n"
+              - "}\n"
 
-            - "extension_config() {\n"
-            - "  echo Configuring extensions and security in neo4j.conf...\n"
-            - "  sed -i s~#server.unmanaged_extension_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged~server.unmanaged_extension_classes=com.neo4j.bloom.server=/bloom,semantics.extension=/rdf~g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#dbms.security.procedures.unrestricted=my.extensions.example,my.procedures.*/dbms.security.procedures.unrestricted=gds.*,apoc.*,bloom.*/g /etc/neo4j/neo4j.conf\n"
-            - "  echo \"dbms.security.http_auth_allowlist=/,/browser.*,/bloom.*\" >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"dbms.security.procedures.allowlist=apoc.*,gds.*,bloom.*\" >> /etc/neo4j/neo4j.conf\n"
-            - "}\n"
+              - "extension_config() {\n"
+              - "  echo Configuring extensions and security in neo4j.conf...\n"
+              - "  sed -i s~#server.unmanaged_extension_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged~server.unmanaged_extension_classes=com.neo4j.bloom.server=/bloom,semantics.extension=/rdf~g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#dbms.security.procedures.unrestricted=my.extensions.example,my.procedures.*/dbms.security.procedures.unrestricted=gds.*,apoc.*,bloom.*/g /etc/neo4j/neo4j.conf\n"
+              - "  echo \"dbms.security.http_auth_allowlist=/,/browser.*,/bloom.*\" >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"dbms.security.procedures.allowlist=apoc.*,gds.*,bloom.*\" >> /etc/neo4j/neo4j.conf\n"
+              - "}\n"
 
-            - "build_neo4j_conf_file() {\n"
-            - "  local -r privateIP=\"$(hostname -i | awk '{print $NF}')\"\n"
-            - "  echo \"Configuring network in neo4j.conf...\"\n"
-            - "  sed -i 's/#server.default_listen_address=0.0.0.0/server.default_listen_address=0.0.0.0/g' /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.default_advertised_address=localhost/server.default_advertised_address=\"${loadBalancerDNSName}\"/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.discovery.advertised_address=:5000/server.discovery.advertised_address=\"${privateIP}\":5000/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.cluster.advertised_address=:6000/server.cluster.advertised_address=\"${privateIP}\":6000/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.cluster.raft.advertised_address=:7000/server.cluster.raft.advertised_address=\"${privateIP}\":7000/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.routing.advertised_address=:7688/server.routing.advertised_address=\"${privateIP}\":7688/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.discovery.listen_address=:5000/server.discovery.listen_address=\"${privateIP}\":5000/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.routing.listen_address=0.0.0.0:7688/server.routing.listen_address=\"${privateIP}\":7688/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.cluster.listen_address=:6000/server.cluster.listen_address=\"${privateIP}\":6000/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.cluster.raft.listen_address=:7000/server.cluster.raft.listen_address=\"${privateIP}\":7000/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.bolt.listen_address=:7687/server.bolt.listen_address=\"${privateIP}\":7687/g /etc/neo4j/neo4j.conf\n"
-            - "  sed -i s/#server.bolt.advertised_address=:7687/server.bolt.advertised_address=\"${privateIP}\":7687/g /etc/neo4j/neo4j.conf\n"
-            - "  neo4j-admin server memory-recommendation >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"server.metrics.enabled=true\" >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"server.metrics.jmx.enabled=true\" >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"server.metrics.prefix=neo4j\" >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"server.metrics.filter=*\" >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"server.metrics.csv.interval=5s\" >> /etc/neo4j/neo4j.conf\n"
-            - "  echo \"dbms.routing.default_router=SERVER\" >> /etc/neo4j/neo4j.conf\n"
+              - "build_neo4j_conf_file() {\n"
+              - "  local -r privateIP=\"$(hostname -i | awk '{print $NF}')\"\n"
+              - "  echo \"Configuring network in neo4j.conf...\"\n"
+              - "  sed -i 's/#server.default_listen_address=0.0.0.0/server.default_listen_address=0.0.0.0/g' /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.default_advertised_address=localhost/server.default_advertised_address=\"${loadBalancerDNSName}\"/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.discovery.advertised_address=:5000/server.discovery.advertised_address=\"${privateIP}\":5000/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.cluster.advertised_address=:6000/server.cluster.advertised_address=\"${privateIP}\":6000/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.cluster.raft.advertised_address=:7000/server.cluster.raft.advertised_address=\"${privateIP}\":7000/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.routing.advertised_address=:7688/server.routing.advertised_address=\"${privateIP}\":7688/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.discovery.listen_address=:5000/server.discovery.listen_address=\"${privateIP}\":5000/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.routing.listen_address=0.0.0.0:7688/server.routing.listen_address=\"${privateIP}\":7688/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.cluster.listen_address=:6000/server.cluster.listen_address=\"${privateIP}\":6000/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.cluster.raft.listen_address=:7000/server.cluster.raft.listen_address=\"${privateIP}\":7000/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.bolt.listen_address=:7687/server.bolt.listen_address=\"${privateIP}\":7687/g /etc/neo4j/neo4j.conf\n"
+              - "  sed -i s/#server.bolt.advertised_address=:7687/server.bolt.advertised_address=\"${privateIP}\":7687/g /etc/neo4j/neo4j.conf\n"
+              - "  neo4j-admin server memory-recommendation >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"server.metrics.enabled=true\" >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"server.metrics.jmx.enabled=true\" >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"server.metrics.prefix=neo4j\" >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"server.metrics.filter=*\" >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"server.metrics.csv.interval=5s\" >> /etc/neo4j/neo4j.conf\n"
+              - "  echo \"dbms.routing.default_router=SERVER\" >> /etc/neo4j/neo4j.conf\n"
 
-            - "  if [[ ${nodeCount} == 1 ]]; then\n"
-            - "    echo \"Running on a single node.\"\n"
-            - "  else\n"
-            - "    echo \"Running on multiple nodes.  Configuring membership in neo4j.conf...\"\n"
-            - "    sed -i s/#initial.dbms.default_primaries_count=1/initial.dbms.default_primaries_count=3/g /etc/neo4j/neo4j.conf\n"
-            - "    sed -i s/#initial.dbms.default_secondaries_count=0/initial.dbms.default_secondaries_count=$(expr ${nodeCount} - 3)/g /etc/neo4j/neo4j.conf\n"
-            - "    sed -i s/#server.bolt.listen_address=:7687/server.bolt.listen_address=\"${privateIP}\":7687/g /etc/neo4j/neo4j.conf\n"
-            - "    echo \"dbms.cluster.minimum_initial_system_primaries_count=${nodeCount}\" >> /etc/neo4j/neo4j.conf\n"
-            - "    TOKEN=$(curl -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")\n"
-            - "    instanceId=$(curl -H \"X-aws-ec2-metadata-token: $TOKEN\" -s http://169.254.169.254/latest/meta-data/instance-id)\n"
-            - "    if [[ ${#instanceId} -eq 0 ]]; then\n"
-            - "     echo \"Missing instance Id. Exiting!! \"\n"
-            - "    fi\n"
-            - "    coreMembers=$(aws autoscaling describe-auto-scaling-instances --region $region --output text --query \"AutoScalingInstances[?contains(AutoScalingGroupName,'$stackName-Neo4jAutoScalingGroup')].[InstanceId]\" | xargs -n1 -I {} aws ec2 describe-instances --instance-ids {} --region $region --query \"Reservations[].Instances[].PrivateIpAddress\" --output text --filter \"Name=tag:aws:cloudformation:stack-name,Values=$stackName\")\n"
-            - "    if [[ ${#coreMembers} -eq 0 ]]; then\n"
-            - "     echo \"Missing coreMembers. Exiting!! \"\n"
-            - "    fi\n"
-            - "    echo \"CoreMembers = ${coreMembers}\"\n"
-            - "    coreMembers=$(echo ${coreMembers} | sed 's/ /:5000,/g')\n"
-            - "    coreMembers=$(echo \"${coreMembers}\"):5000\n"
-            - "    sed -i s/#dbms.cluster.discovery.endpoints=localhost:5000,localhost:5001,localhost:5002/dbms.cluster.discovery.endpoints=${coreMembers}/g /etc/neo4j/neo4j.conf\n"
-            - "  fi\n"
-            - "}\n"
+              - "  if [[ ${nodeCount} == 1 ]]; then\n"
+              - "    echo \"Running on a single node.\"\n"
+              - "  else\n"
+              - "    echo \"Running on multiple nodes.  Configuring membership in neo4j.conf...\"\n"
+              - "    sed -i s/#initial.dbms.default_primaries_count=1/initial.dbms.default_primaries_count=3/g /etc/neo4j/neo4j.conf\n"
+              - "    sed -i s/#initial.dbms.default_secondaries_count=0/initial.dbms.default_secondaries_count=$(expr ${nodeCount} - 3)/g /etc/neo4j/neo4j.conf\n"
+              - "    sed -i s/#server.bolt.listen_address=:7687/server.bolt.listen_address=\"${privateIP}\":7687/g /etc/neo4j/neo4j.conf\n"
+              - "    echo \"dbms.cluster.minimum_initial_system_primaries_count=${nodeCount}\" >> /etc/neo4j/neo4j.conf\n"
+              - "    TOKEN=$(curl -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")\n"
+              - "    instanceId=$(curl -H \"X-aws-ec2-metadata-token: $TOKEN\" -s http://169.254.169.254/latest/meta-data/instance-id)\n"
+              - "    if [[ ${#instanceId} -eq 0 ]]; then\n"
+              - "     echo \"Missing instance Id. Exiting!! \"\n"
+              - "    fi\n"
+              - "    coreMembers=$(aws autoscaling describe-auto-scaling-instances --region $region --output text --query \"AutoScalingInstances[?contains(AutoScalingGroupName,'$stackName-Neo4jAutoScalingGroup')].[InstanceId]\" | xargs -n1 -I {} aws ec2 describe-instances --instance-ids {} --region $region --query \"Reservations[].Instances[].PrivateIpAddress\" --output text --filter \"Name=tag:aws:cloudformation:stack-name,Values=$stackName\")\n"
+              - "    if [[ ${#coreMembers} -eq 0 ]]; then\n"
+              - "     echo \"Missing coreMembers. Exiting!! \"\n"
+              - "    fi\n"
+              - "    echo \"CoreMembers = ${coreMembers}\"\n"
+              - "    coreMembers=$(echo ${coreMembers} | sed 's/ /:5000,/g')\n"
+              - "    coreMembers=$(echo \"${coreMembers}\"):5000\n"
+              - "    sed -i s/#dbms.cluster.discovery.endpoints=localhost:5000,localhost:5001,localhost:5002/dbms.cluster.discovery.endpoints=${coreMembers}/g /etc/neo4j/neo4j.conf\n"
+              - "  fi\n"
+              - "}\n"
 
-            - "configure_graph_data_science() {\n"
-            - "  if [[ \"${installGraphDataScience}\" == Yes && \"${nodeCount}\" == 1 ]]; then\n"
-            - "    echo \"Installing Graph Data Science...\"\n"
-            - "    cp -p /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins\n"
-            - "  fi\n"
-            - "  if [[ $graphDataScienceLicenseKey != None ]]; then\n"
-            - "    echo \"Writing GDS license key...\"\n"
-            - "    mkdir -p /etc/neo4j/licenses\n"
-            - "    chown neo4j:neo4j /etc/neo4j/licenses\n"
-            - "    echo \"${graphDataScienceLicenseKey}\" > /etc/neo4j/licenses/neo4j-gds.license\n"
-            - "    sed -i '$a gds.enterprise.license_file=/etc/neo4j/licenses/neo4j-gds.license' /etc/neo4j/neo4j.conf\n"
-            - "  fi\n"
-            - "}\n"
+              - "configure_graph_data_science() {\n"
+              - "  if [[ \"${installGraphDataScience}\" == Yes && \"${nodeCount}\" == 1 ]]; then\n"
+              - "    echo \"Installing Graph Data Science...\"\n"
+              - "    cp -p /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins\n"
+              - "  fi\n"
+              - "  if [[ $graphDataScienceLicenseKey != None ]]; then\n"
+              - "    echo \"Writing GDS license key...\"\n"
+              - "    mkdir -p /etc/neo4j/licenses\n"
+              - "    chown neo4j:neo4j /etc/neo4j/licenses\n"
+              - "    echo \"${graphDataScienceLicenseKey}\" > /etc/neo4j/licenses/neo4j-gds.license\n"
+              - "    sed -i '$a gds.enterprise.license_file=/etc/neo4j/licenses/neo4j-gds.license' /etc/neo4j/neo4j.conf\n"
+              - "  fi\n"
+              - "}\n"
 
-            - "configure_bloom() {\n"
-            - "  if [[ $installBloom == Yes ]]; then\n"
-            - "    echo \"Installing Bloom...\"\n"
-            - "    cp -p /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins\n"
-            - "  fi\n"
-            - "  if [[ $bloomLicenseKey != None ]]; then\n"
-            - "    echo \"Writing Bloom license key...\"\n"
-            - "    mkdir -p /etc/neo4j/licenses\n"
-            - "    chown neo4j:neo4j /etc/neo4j/licenses\n"
-            - "    echo \"${bloomLicenseKey}\" > /etc/neo4j/licenses/neo4j-bloom.license\n"
-            - "    sed -i '$a dbms.bloom.license_file=/etc/neo4j/licenses/neo4j-bloom.license' /etc/neo4j/neo4j.conf\n"
-            - "  fi\n"
-            - "}\n"
+              - "configure_bloom() {\n"
+              - "  if [[ $installBloom == Yes ]]; then\n"
+              - "    echo \"Installing Bloom...\"\n"
+              - "    cp -p /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins\n"
+              - "  fi\n"
+              - "  if [[ $bloomLicenseKey != None ]]; then\n"
+              - "    echo \"Writing Bloom license key...\"\n"
+              - "    mkdir -p /etc/neo4j/licenses\n"
+              - "    chown neo4j:neo4j /etc/neo4j/licenses\n"
+              - "    echo \"${bloomLicenseKey}\" > /etc/neo4j/licenses/neo4j-bloom.license\n"
+              - "    sed -i '$a dbms.bloom.license_file=/etc/neo4j/licenses/neo4j-bloom.license' /etc/neo4j/neo4j.conf\n"
+              - "  fi\n"
+              - "}\n"
 
-            - "start_neo4j() {\n"
-            - "  echo \"Starting Neo4j...\"\n"
-            - "  service neo4j start\n"
-            - "  neo4j-admin dbms set-initial-password \"${password}\"\n"
-            - "  while [[ \"$(curl -s -o /dev/null -m 3 -L -w '%{http_code}' http://localhost:7474 )\" != \"200\" ]];\n"
-            - "    do echo \"Waiting for cluster to start\"\n"
-            - "    sleep 5\n"
-            - "  done\n"
-            - "}\n"
+              - "start_neo4j() {\n"
+              - "  echo \"Starting Neo4j...\"\n"
+              - "  service neo4j start\n"
+              - "  neo4j-admin dbms set-initial-password \"${password}\"\n"
+              - "  while [[ \"$(curl -s -o /dev/null -m 3 -L -w '%{http_code}' http://localhost:7474 )\" != \"200\" ]];\n"
+              - "    do echo \"Waiting for cluster to start\"\n"
+              - "    sleep 5\n"
+              - "  done\n"
+              - "}\n"
 
-            - "tag_asg_with_neo4j_version() {\n"
-            - "  if [[ -z $NEO4J_VERSION_ASG_TAG ]]; then\n"
-            - "    echo \"Tagging AutoScalingGroup $ASG_NAME with Key NEO4J_VERSION and Value $PACKAGE_VERSION\"\n"
-            - "    aws --region $region autoscaling create-or-update-tags --tags ResourceId=$ASG_NAME,ResourceType=auto-scaling-group,Key=NEO4J_VERSION,Value=$PACKAGE_VERSION,PropagateAtLaunch=true\n"
-            - "  else\n"
-            - "    echo \"ASG is already tagged with NEO4J_VERSION\"\n"
-            - "  fi\n"
-            - "  /opt/aws/bin/cfn-signal -e $? --stack \"${stackName}\" --resource Neo4jAutoScalingGroup --region \"${region}\"\n"
-            - "}\n"
+              - "tag_asg_with_neo4j_version() {\n"
+              - "  if [[ -z $NEO4J_VERSION_ASG_TAG ]]; then\n"
+              - "    echo \"Tagging AutoScalingGroup $ASG_NAME with Key NEO4J_VERSION and Value $PACKAGE_VERSION\"\n"
+              - "    aws --region $region autoscaling create-or-update-tags --tags ResourceId=$ASG_NAME,ResourceType=auto-scaling-group,Key=NEO4J_VERSION,Value=$PACKAGE_VERSION,PropagateAtLaunch=true\n"
+              - "  else\n"
+              - "    echo \"ASG is already tagged with NEO4J_VERSION\"\n"
+              - "  fi\n"
+              - "  /opt/aws/bin/cfn-signal -e $? --stack \"${stackName}\" --resource Neo4jAutoScalingGroup --region \"${region}\"\n"
+              - "}\n"
 
-            - "add_cypher_ip_blocklist() {\n"
-            - "  echo \"internal.dbms.cypher_ip_blocklist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.169.0/24,fc00::/7,fe80::/10,ff00::/8\" >> /etc/neo4j/neo4j.conf\n"
-            - "}\n"
+              - "add_cypher_ip_blocklist() {\n"
+              - "  echo \"internal.dbms.cypher_ip_blocklist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.169.0/24,fc00::/7,fe80::/10,ff00::/8\" >> /etc/neo4j/neo4j.conf\n"
+              - "}\n"
 
-            - "install_neo4j_from_yum\n"
-            - "install_apoc_plugin\n"
-            - "extension_config\n"
-            - "build_neo4j_conf_file\n"
-            - "configure_graph_data_science\n"
-            - "configure_bloom\n"
-            - "add_cypher_ip_blocklist\n"
-            - "start_neo4j\n"
-            - "tag_asg_with_neo4j_version\n"
+              - "install_neo4j_from_yum\n"
+              - "install_apoc_plugin\n"
+              - "extension_config\n"
+              - "build_neo4j_conf_file\n"
+              - "configure_graph_data_science\n"
+              - "configure_bloom\n"
+              - "add_cypher_ip_blocklist\n"
+              - "start_neo4j\n"
+              - "tag_asg_with_neo4j_version\n"
 
   Neo4jInstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
The template for neo4j enterprise now uses a AWS::EC2::LaunchTemplate instead of the previous AWS::AutoScaling::LaunchConfiguration which has now been deprecated on AWS