### PR TITLE
Install Bloom plugin and add --bloom/gds-license-secret-id flags to deploy.py

### DIFF
--- a/neo4j-ee/deploy.py
+++ b/neo4j-ee/deploy.py
@@ -85,6 +85,18 @@ def parse_args():
     p.add_argument("--disk-size", type=int, metavar="GB", help="Data volume size in GB (default: 100, min: 100, max: 65536)")
     p.add_argument("--snapshot-id", metavar="SNAPSHOT_ID", help="Snapshot ID to restore Node 1 data volume from (must match --disk-size)")
     p.add_argument(
+        "--bloom-license-secret-id", metavar="SECRET",
+        help="Secrets Manager secret name or ARN holding the Bloom licence JWT. "
+             "When set, deploy.py installs the licence on each cluster node "
+             "post-deploy and restarts neo4j so Bloom enters Enterprise mode.",
+    )
+    p.add_argument(
+        "--gds-license-secret-id", metavar="SECRET",
+        help="Secrets Manager secret name or ARN holding the GDS Enterprise licence. "
+             "When set, deploy.py installs the licence on each cluster node "
+             "post-deploy so GDS enters Enterprise mode (gds.isLicensed() returns true).",
+    )
+    p.add_argument(
         "--vpc-file", metavar="PATH",
         help="Path to vpc-*.txt from scripts/create-test-vpc.py. "
              "Auto-detected from .deploy/vpc-*.txt when --mode ExistingVpc and --vpc-id is not provided. "
@@ -152,6 +164,184 @@ def generate_tls_cert(nlb_dns):
         serialization.NoEncryption(),
     ).decode()
     return cert_pem, key_pem
+
+
+def install_licenses(stack_name, region, bloom_secret, gds_secret):
+    """Rolling SSM install of Bloom and/or GDS licence files onto each cluster
+    instance. Skipped if both args are empty. Attaches a stack-role inline
+    policy granting secretsmanager:GetSecretValue on the requested secret
+    ARNs; SSM Run Command on each instance fetches via the role and writes
+    the licence to /var/lib/neo4j/licenses/, then restarts neo4j and waits
+    for target-group health. Verifies via cypher-shell on the first node.
+
+    Assumes the install-bloom upstream change is in the template — i.e., the
+    UserData already copies the plugin JARs and writes dbms.bloom.license_file
+    / gds.enterprise.license_file into neo4j.conf.
+    """
+    if not (bloom_secret or gds_secret):
+        return
+
+    print()
+    print("--- Licence install phase ---")
+    cfn = boto3.client("cloudformation", region_name=region)
+    iam = boto3.client("iam", region_name=region)
+    ec2 = boto3.client("ec2", region_name=region)
+    ssm = boto3.client("ssm", region_name=region)
+    elbv2 = boto3.client("elbv2", region_name=region)
+    sm = boto3.client("secretsmanager", region_name=region)
+
+    # Resolve names to ARNs so the IAM policy can be tightly scoped.
+    bloom_arn = sm.describe_secret(SecretId=bloom_secret)["ARN"] if bloom_secret else None
+    gds_arn = sm.describe_secret(SecretId=gds_secret)["ARN"] if gds_secret else None
+    arns = [a for a in (bloom_arn, gds_arn) if a]
+
+    role_name = cfn.describe_stack_resource(
+        StackName=stack_name, LogicalResourceId="Neo4jRole"
+    )["StackResourceDetail"]["PhysicalResourceId"]
+    print(f"Attaching inline policy 'Neo4jLicenseSecretsRead' to {role_name}")
+    iam.put_role_policy(
+        RoleName=role_name,
+        PolicyName="Neo4jLicenseSecretsRead",
+        PolicyDocument=json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Sid": "ReadNeo4jLicenses",
+                "Effect": "Allow",
+                "Action": "secretsmanager:GetSecretValue",
+                "Resource": arns,
+            }],
+        }),
+    )
+
+    # Filter on Role=neo4j-cluster-node so bastion instances (created in --mode
+    # Private / ExistingVpc) are excluded — they use a different IAM role and
+    # the licence file isn't needed there.
+    reservations = ec2.describe_instances(
+        Filters=[
+            {"Name": "tag:aws:cloudformation:stack-name", "Values": [stack_name]},
+            {"Name": "tag:Role", "Values": ["neo4j-cluster-node"]},
+            {"Name": "instance-state-name", "Values": ["running"]},
+        ]
+    )["Reservations"]
+    instance_ids = sorted(
+        i["InstanceId"] for r in reservations for i in r["Instances"]
+    )
+    print(f"Cluster instances: {instance_ids}")
+
+    tg_http = cfn.describe_stack_resource(
+        StackName=stack_name, LogicalResourceId="Neo4jHTTPTargetGroup"
+    )["StackResourceDetail"]["PhysicalResourceId"]
+
+    # _fetch_secret retries 6x over 60s to absorb IAM propagation between
+    # put-role-policy and STS evaluating the new permission on the instance.
+    cmds = [
+        "set -euo pipefail",
+        (
+            "_fetch_secret() { local arn=$1 dest=$2; for i in 1 2 3 4 5 6; do "
+            f"if aws secretsmanager get-secret-value --region {region} "
+            "--secret-id \"$arn\" --query SecretString --output text "
+            "2>/tmp/getval.err | tr -d '\\n' > \"$dest\" && test -s \"$dest\"; "
+            "then return 0; fi; echo \"  fetch $arn attempt $i: $(cat /tmp/getval.err)\"; "
+            "sleep 10; done; echo \"ERROR: could not fetch $arn after 6 attempts\"; "
+            "return 1; }"
+        ),
+        "mkdir -p /var/lib/neo4j/licenses",
+    ]
+    if bloom_arn:
+        cmds += [
+            f"_fetch_secret '{bloom_arn}' /var/lib/neo4j/licenses/neo4j-bloom.license",
+            "chown neo4j:neo4j /var/lib/neo4j/licenses/neo4j-bloom.license",
+            "chmod 640 /var/lib/neo4j/licenses/neo4j-bloom.license",
+        ]
+    if gds_arn:
+        cmds += [
+            f"_fetch_secret '{gds_arn}' /var/lib/neo4j/licenses/neo4j-gds.license",
+            "chown neo4j:neo4j /var/lib/neo4j/licenses/neo4j-gds.license",
+            "chmod 640 /var/lib/neo4j/licenses/neo4j-gds.license",
+        ]
+    cmds += [
+        "systemctl restart neo4j",
+        ("for i in $(seq 1 60); do curl -sf http://localhost:7474/ -o /dev/null "
+         "&& break; sleep 5; done"),
+        "curl -sf http://localhost:7474/ -o /dev/null",
+    ]
+
+    for inst in instance_ids:
+        print(f"\n>> SSM licence install on {inst}")
+        cmd_id = ssm.send_command(
+            InstanceIds=[inst],
+            DocumentName="AWS-RunShellScript",
+            Parameters={"commands": cmds},
+            TimeoutSeconds=600,
+        )["Command"]["CommandId"]
+        _wait_ssm(ssm, cmd_id, inst)
+        _wait_tg_healthy(elbv2, tg_http, inst)
+
+    print("\n--- Verifying licences via cypher-shell on first node ---")
+    verify_cmds = [
+        "set -uo pipefail",
+        (
+            f"export NEO4J_PASSWORD=$(aws secretsmanager get-secret-value "
+            f"--region {region} --secret-id neo4j/{stack_name}/password "
+            f"--query SecretString --output text)"
+        ),
+    ]
+    if bloom_arn:
+        verify_cmds += [
+            "echo '--- bloom.checkLicenseCompliance ---'",
+            ("cypher-shell -a neo4j://localhost:7687 -u neo4j --format plain "
+             "--non-interactive 'CALL bloom.checkLicenseCompliance();'"),
+        ]
+    if gds_arn:
+        verify_cmds += [
+            "echo '--- gds.isLicensed ---'",
+            ("cypher-shell -a neo4j://localhost:7687 -u neo4j --format plain "
+             "--non-interactive 'RETURN gds.isLicensed() AS isLicensed;'"),
+            "echo '--- gds.debug.sysInfo gdsEdition ---'",
+            ("cypher-shell -a neo4j://localhost:7687 -u neo4j --format plain "
+             "--non-interactive \"CALL gds.debug.sysInfo() YIELD key, value "
+             "WHERE key = 'gdsEdition' RETURN key, value;\""),
+        ]
+    cmd_id = ssm.send_command(
+        InstanceIds=[instance_ids[0]],
+        DocumentName="AWS-RunShellScript",
+        Parameters={"commands": verify_cmds},
+        TimeoutSeconds=120,
+    )["Command"]["CommandId"]
+    _wait_ssm(ssm, cmd_id, instance_ids[0])
+    print(ssm.get_command_invocation(
+        CommandId=cmd_id, InstanceId=instance_ids[0],
+    )["StandardOutputContent"])
+
+
+def _wait_ssm(ssm, cmd_id, instance_id):
+    while True:
+        try:
+            inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=instance_id)
+        except ssm.exceptions.InvocationDoesNotExist:
+            # SSM SendCommand returns a CommandId synchronously, but the
+            # per-instance invocation record isn't created until the SSM agent
+            # picks the command up — usually a few seconds. Retry until it
+            # appears.
+            time.sleep(5)
+            continue
+        if inv["Status"] == "Success":
+            return
+        if inv["Status"] in ("Failed", "Cancelled", "TimedOut"):
+            print(inv["StandardOutputContent"])
+            print(inv["StandardErrorContent"], file=sys.stderr)
+            sys.exit(f"ERROR: SSM command {cmd_id} on {instance_id}: {inv['Status']}")
+        time.sleep(5)
+
+
+def _wait_tg_healthy(elbv2, tg_arn, instance_id, attempts=30, delay=10):
+    for _ in range(attempts):
+        targets = elbv2.describe_target_health(TargetGroupArn=tg_arn)["TargetHealthDescriptions"]
+        for t in targets:
+            if t["Target"]["Id"] == instance_id and t["TargetHealth"]["State"] == "healthy":
+                return
+        time.sleep(delay)
+    sys.exit(f"ERROR: {instance_id} did not reach healthy in target group")
 
 
 def main():
@@ -469,6 +659,13 @@ def main():
         print("TLS enabled on Bolt. To activate on the Lambda:")
         print(f"  cd {SCRIPT_DIR}/sample-private-app && cdk deploy")
         print("(neo4j-ca.crt is already staged in the lambda/ directory)")
+
+    install_licenses(
+        stack_name=stack_name,
+        region=region,
+        bloom_secret=args.bloom_license_secret_id,
+        gds_secret=args.gds_license_secret_id,
+    )
 
     deploy_dir = os.path.join(SCRIPT_DIR, ".deploy")
     os.makedirs(deploy_dir, exist_ok=True)

--- a/neo4j-ee/templates/neo4j-private-existing-vpc.template.yaml
+++ b/neo4j-ee/templates/neo4j-private-existing-vpc.template.yaml
@@ -914,6 +914,11 @@ Resources:
                   cp /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || \
                   cp /var/lib/neo4j/products/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || true
                 }
+                install_bloom() {
+                  echo "Installing Bloom plugin..."
+                  cp /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins/
+                  chown neo4j:neo4j /var/lib/neo4j/plugins/bloom-plugin-*.jar
+                }
                 install_gds() {
                   echo "Installing Graph Data Science plugin..."
                   cp /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins/
@@ -921,6 +926,15 @@ Resources:
                 extension_config() {
                   echo Configuring extensions and security in neo4j.conf...
                   set_neo4j_conf server.unmanaged_extension_classes "com.neo4j.bloom.server=/bloom,semantics.extension=/rdf"
+                  # Bloom and GDS Enterprise do not auto-discover their licence files.
+                  # Without these settings, bloom.checkLicenseCompliance() returns "missing"
+                  # and gds.isLicensed() returns false even when the licence files are on disk.
+                  # Matches the canonical config keys used by neo4j/docker-neo4j and
+                  # neo4j/helm-charts (examples/bloom-gds-license/gds-bloom-with-license.yaml).
+                  set_neo4j_conf dbms.bloom.license_file /var/lib/neo4j/licenses/neo4j-bloom.license
+                  if [[ "${installGDS}" == "true" ]]; then
+                    set_neo4j_conf gds.enterprise.license_file /var/lib/neo4j/licenses/neo4j-gds.license
+                  fi
                   set_neo4j_conf dbms.security.procedures.unrestricted "gds.*,apoc.*,bloom.*"
                   set_neo4j_conf dbms.security.http_auth_allowlist "/,/browser.*,/bloom.*"
                   set_neo4j_conf dbms.security.procedures.allowlist "apoc.*,gds.*,bloom.*"
@@ -1075,6 +1089,7 @@ Resources:
                 attach_and_mount_data_volume
                 install_neo4j_from_yum
                 install_apoc
+                install_bloom
                 if [[ "${installGDS}" == "true" ]]; then
                   install_gds
                 fi

--- a/neo4j-ee/templates/neo4j-private.template.yaml
+++ b/neo4j-ee/templates/neo4j-private.template.yaml
@@ -843,6 +843,11 @@ Resources:
                   cp /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || \
                   cp /var/lib/neo4j/products/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || true
                 }
+                install_bloom() {
+                  echo "Installing Bloom plugin..."
+                  cp /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins/
+                  chown neo4j:neo4j /var/lib/neo4j/plugins/bloom-plugin-*.jar
+                }
                 install_gds() {
                   echo "Installing Graph Data Science plugin..."
                   cp /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins/
@@ -850,6 +855,15 @@ Resources:
                 extension_config() {
                   echo Configuring extensions and security in neo4j.conf...
                   set_neo4j_conf server.unmanaged_extension_classes "com.neo4j.bloom.server=/bloom,semantics.extension=/rdf"
+                  # Bloom and GDS Enterprise do not auto-discover their licence files.
+                  # Without these settings, bloom.checkLicenseCompliance() returns "missing"
+                  # and gds.isLicensed() returns false even when the licence files are on disk.
+                  # Matches the canonical config keys used by neo4j/docker-neo4j and
+                  # neo4j/helm-charts (examples/bloom-gds-license/gds-bloom-with-license.yaml).
+                  set_neo4j_conf dbms.bloom.license_file /var/lib/neo4j/licenses/neo4j-bloom.license
+                  if [[ "${installGDS}" == "true" ]]; then
+                    set_neo4j_conf gds.enterprise.license_file /var/lib/neo4j/licenses/neo4j-gds.license
+                  fi
                   set_neo4j_conf dbms.security.procedures.unrestricted "gds.*,apoc.*,bloom.*"
                   set_neo4j_conf dbms.security.http_auth_allowlist "/,/browser.*,/bloom.*"
                   set_neo4j_conf dbms.security.procedures.allowlist "apoc.*,gds.*,bloom.*"
@@ -1004,6 +1018,7 @@ Resources:
                 attach_and_mount_data_volume
                 install_neo4j_from_yum
                 install_apoc
+                install_bloom
                 if [[ "${installGDS}" == "true" ]]; then
                   install_gds
                 fi

--- a/neo4j-ee/templates/neo4j-public.template.yaml
+++ b/neo4j-ee/templates/neo4j-public.template.yaml
@@ -773,6 +773,11 @@ Resources:
                   cp /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || \
                   cp /var/lib/neo4j/products/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || true
                 }
+                install_bloom() {
+                  echo "Installing Bloom plugin..."
+                  cp /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins/
+                  chown neo4j:neo4j /var/lib/neo4j/plugins/bloom-plugin-*.jar
+                }
                 install_gds() {
                   echo "Installing Graph Data Science plugin..."
                   cp /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins/
@@ -780,6 +785,15 @@ Resources:
                 extension_config() {
                   echo Configuring extensions and security in neo4j.conf...
                   set_neo4j_conf server.unmanaged_extension_classes "com.neo4j.bloom.server=/bloom,semantics.extension=/rdf"
+                  # Bloom and GDS Enterprise do not auto-discover their licence files.
+                  # Without these settings, bloom.checkLicenseCompliance() returns "missing"
+                  # and gds.isLicensed() returns false even when the licence files are on disk.
+                  # Matches the canonical config keys used by neo4j/docker-neo4j and
+                  # neo4j/helm-charts (examples/bloom-gds-license/gds-bloom-with-license.yaml).
+                  set_neo4j_conf dbms.bloom.license_file /var/lib/neo4j/licenses/neo4j-bloom.license
+                  if [[ "${installGDS}" == "true" ]]; then
+                    set_neo4j_conf gds.enterprise.license_file /var/lib/neo4j/licenses/neo4j-gds.license
+                  fi
                   set_neo4j_conf dbms.security.procedures.unrestricted "gds.*,apoc.*,bloom.*"
                   set_neo4j_conf dbms.security.http_auth_allowlist "/,/browser.*,/bloom.*"
                   set_neo4j_conf dbms.security.procedures.allowlist "apoc.*,gds.*,bloom.*"
@@ -934,6 +948,7 @@ Resources:
                 attach_and_mount_data_volume
                 install_neo4j_from_yum
                 install_apoc
+                install_bloom
                 if [[ "${installGDS}" == "true" ]]; then
                   install_gds
                 fi

--- a/neo4j-ee/templates/src/userdata-existing-vpc.sh
+++ b/neo4j-ee/templates/src/userdata-existing-vpc.sh
@@ -161,6 +161,11 @@ install_apoc() {
   cp /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || \
   cp /var/lib/neo4j/products/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || true
 }
+install_bloom() {
+  echo "Installing Bloom plugin..."
+  cp /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins/
+  chown neo4j:neo4j /var/lib/neo4j/plugins/bloom-plugin-*.jar
+}
 install_gds() {
   echo "Installing Graph Data Science plugin..."
   cp /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins/
@@ -168,6 +173,15 @@ install_gds() {
 extension_config() {
   echo Configuring extensions and security in neo4j.conf...
   set_neo4j_conf server.unmanaged_extension_classes "com.neo4j.bloom.server=/bloom,semantics.extension=/rdf"
+  # Bloom and GDS Enterprise do not auto-discover their licence files.
+  # Without these settings, bloom.checkLicenseCompliance() returns "missing"
+  # and gds.isLicensed() returns false even when the licence files are on disk.
+  # Matches the canonical config keys used by neo4j/docker-neo4j and
+  # neo4j/helm-charts (examples/bloom-gds-license/gds-bloom-with-license.yaml).
+  set_neo4j_conf dbms.bloom.license_file /var/lib/neo4j/licenses/neo4j-bloom.license
+  if [[ "${installGDS}" == "true" ]]; then
+    set_neo4j_conf gds.enterprise.license_file /var/lib/neo4j/licenses/neo4j-gds.license
+  fi
   set_neo4j_conf dbms.security.procedures.unrestricted "gds.*,apoc.*,bloom.*"
   set_neo4j_conf dbms.security.http_auth_allowlist "/,/browser.*,/bloom.*"
   set_neo4j_conf dbms.security.procedures.allowlist "apoc.*,gds.*,bloom.*"
@@ -322,6 +336,7 @@ pin_neo4j_user
 attach_and_mount_data_volume
 install_neo4j_from_yum
 install_apoc
+install_bloom
 if [[ "${installGDS}" == "true" ]]; then
   install_gds
 fi

--- a/neo4j-ee/templates/src/userdata-private.sh
+++ b/neo4j-ee/templates/src/userdata-private.sh
@@ -161,6 +161,11 @@ install_apoc() {
   cp /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || \
   cp /var/lib/neo4j/products/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || true
 }
+install_bloom() {
+  echo "Installing Bloom plugin..."
+  cp /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins/
+  chown neo4j:neo4j /var/lib/neo4j/plugins/bloom-plugin-*.jar
+}
 install_gds() {
   echo "Installing Graph Data Science plugin..."
   cp /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins/
@@ -168,6 +173,15 @@ install_gds() {
 extension_config() {
   echo Configuring extensions and security in neo4j.conf...
   set_neo4j_conf server.unmanaged_extension_classes "com.neo4j.bloom.server=/bloom,semantics.extension=/rdf"
+  # Bloom and GDS Enterprise do not auto-discover their licence files.
+  # Without these settings, bloom.checkLicenseCompliance() returns "missing"
+  # and gds.isLicensed() returns false even when the licence files are on disk.
+  # Matches the canonical config keys used by neo4j/docker-neo4j and
+  # neo4j/helm-charts (examples/bloom-gds-license/gds-bloom-with-license.yaml).
+  set_neo4j_conf dbms.bloom.license_file /var/lib/neo4j/licenses/neo4j-bloom.license
+  if [[ "${installGDS}" == "true" ]]; then
+    set_neo4j_conf gds.enterprise.license_file /var/lib/neo4j/licenses/neo4j-gds.license
+  fi
   set_neo4j_conf dbms.security.procedures.unrestricted "gds.*,apoc.*,bloom.*"
   set_neo4j_conf dbms.security.http_auth_allowlist "/,/browser.*,/bloom.*"
   set_neo4j_conf dbms.security.procedures.allowlist "apoc.*,gds.*,bloom.*"
@@ -322,6 +336,7 @@ pin_neo4j_user
 attach_and_mount_data_volume
 install_neo4j_from_yum
 install_apoc
+install_bloom
 if [[ "${installGDS}" == "true" ]]; then
   install_gds
 fi

--- a/neo4j-ee/templates/src/userdata-public.sh
+++ b/neo4j-ee/templates/src/userdata-public.sh
@@ -161,6 +161,11 @@ install_apoc() {
   cp /var/lib/neo4j/labs/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || \
   cp /var/lib/neo4j/products/apoc-*-core.jar /var/lib/neo4j/plugins/ 2>/dev/null || true
 }
+install_bloom() {
+  echo "Installing Bloom plugin..."
+  cp /var/lib/neo4j/products/bloom-plugin-*.jar /var/lib/neo4j/plugins/
+  chown neo4j:neo4j /var/lib/neo4j/plugins/bloom-plugin-*.jar
+}
 install_gds() {
   echo "Installing Graph Data Science plugin..."
   cp /var/lib/neo4j/products/neo4j-graph-data-science-*.jar /var/lib/neo4j/plugins/
@@ -168,6 +173,15 @@ install_gds() {
 extension_config() {
   echo Configuring extensions and security in neo4j.conf...
   set_neo4j_conf server.unmanaged_extension_classes "com.neo4j.bloom.server=/bloom,semantics.extension=/rdf"
+  # Bloom and GDS Enterprise do not auto-discover their licence files.
+  # Without these settings, bloom.checkLicenseCompliance() returns "missing"
+  # and gds.isLicensed() returns false even when the licence files are on disk.
+  # Matches the canonical config keys used by neo4j/docker-neo4j and
+  # neo4j/helm-charts (examples/bloom-gds-license/gds-bloom-with-license.yaml).
+  set_neo4j_conf dbms.bloom.license_file /var/lib/neo4j/licenses/neo4j-bloom.license
+  if [[ "${installGDS}" == "true" ]]; then
+    set_neo4j_conf gds.enterprise.license_file /var/lib/neo4j/licenses/neo4j-gds.license
+  fi
   set_neo4j_conf dbms.security.procedures.unrestricted "gds.*,apoc.*,bloom.*"
   set_neo4j_conf dbms.security.http_auth_allowlist "/,/browser.*,/bloom.*"
   set_neo4j_conf dbms.security.procedures.allowlist "apoc.*,gds.*,bloom.*"
@@ -322,6 +336,7 @@ pin_neo4j_user
 attach_and_mount_data_volume
 install_neo4j_from_yum
 install_apoc
+install_bloom
 if [[ "${installGDS}" == "true" ]]; then
   install_gds
 fi


### PR DESCRIPTION
## What this does

Makes a fresh Neo4j EE deploy actually run Bloom and GDS in their licensed Enterprise modes. On current `main`, even with licence files at the conventional paths, Bloom's UI returns 404 (the plugin JAR is never copied to `plugins/`) and GDS silently runs in Community mode (`gds.enterprise.license_file` is never set in `neo4j.conf`).

Two coordinated changes, one PR.

### 1. Template: `install_bloom()` + `*.license_file` config keys (commit 1)

`neo4j-ee/templates/src/userdata-{public,private,existing-vpc}.sh` + regenerated YAMLs via `build.py`. +15 lines per partial × 3.

- New `install_bloom()` helper glob-copies `/var/lib/neo4j/products/bloom-plugin-*.jar` → `/var/lib/neo4j/plugins/`. Mirrors the existing `install_apoc()` / `install_gds()` pattern.
- `extension_config()` now writes `dbms.bloom.license_file=/var/lib/neo4j/licenses/neo4j-bloom.license` unconditionally, and `gds.enterprise.license_file=/var/lib/neo4j/licenses/neo4j-gds.license` when `InstallGDS=true`. Neither plugin auto-discovers its licence file; confirmed against [`neo4j/docker-neo4j`](https://github.com/neo4j/docker-neo4j/blob/master/docker-image-src/calver/coredb/neo4j-plugins.json) and [`neo4j/helm-charts`](https://github.com/neo4j/helm-charts/blob/dev/examples/bloom-gds-license/gds-bloom-with-license.yaml).

### 2. `deploy.py`: `--bloom-license-secret-id` and `--gds-license-secret-id` flags (commit 2)

`neo4j-ee/deploy.py`. +197 lines, no deletions.

- Optional flags accept a Secrets Manager secret name or ARN. If neither is passed, the licence install phase is skipped. Existing behaviour is preserved.
- The post-deploy phase (runs *after* any `--tls` instance refresh, so licences land on post-refresh root volumes) attaches a scoped inline IAM policy on the stack's `Neo4jRole` granting `secretsmanager:GetSecretValue` on the resolved secret ARN(s), then SSM Run Command on each cluster instance fetches the licence on-instance (`_fetch_secret` retries 6× over 60s to absorb IAM propagation), writes to `/var/lib/neo4j/licenses/`, restarts neo4j, and waits for target-group health.
- Instance discovery filters by `tag:Role=neo4j-cluster-node`, so the bastion instance created in `--mode Private` / `--mode ExistingVpc` is correctly skipped (it uses `Neo4jBastionRole` and doesn't need licence files).
- `_wait_ssm` tolerates `InvocationDoesNotExist` on the brief window between `SendCommand` returning a CommandId and the SSM agent creating the per-instance invocation record.
- Licence content stays in Secrets Manager throughout; only the ARN appears in CloudTrail / SSM history. Considered a local-file variant (where the licence content is base64-embedded in the SSM command) and rejected because the JWT would land in audit logs.
- Verifies on the first node after install:
  - `CALL bloom.checkLicenseCompliance()` → `status: "valid"`
  - `RETURN gds.isLicensed()` → `TRUE`
  - `CALL gds.debug.sysInfo() YIELD key, value WHERE key='gdsEdition'` → `"Licensed"`

## Canonical alignment

| Source | What it confirms |
|---|---|
| [`docker-neo4j/.../neo4j-plugins.json`](https://github.com/neo4j/docker-neo4j/blob/master/docker-image-src/calver/coredb/neo4j-plugins.json) | Same JAR location, same `dbms.bloom.license_file` setting |
| [`docker-neo4j/.../docker-entrypoint.sh`](https://github.com/neo4j/docker-neo4j/blob/master/docker-image-src/calver/coredb/docker-entrypoint.sh) | Same glob-copy install pattern |
| [`helm-charts/.../gds-bloom-with-license.yaml`](https://github.com/neo4j/helm-charts/blob/dev/examples/bloom-gds-license/gds-bloom-with-license.yaml) | Sets both `*.license_file` keys explicitly |
| [Bloom server install docs](https://neo4j.com/docs/bloom-user-guide/current/bloom-installation/installation-activation/) | `dbms.bloom.license_file=<path>` is documented; no auto-discovery |
| [GDS Enterprise install docs](https://neo4j.com/docs/graph-data-science/current/installation/installation-enterprise-edition/) | `gds.enterprise.license_file=<absolute path>` required; no auto-discovery |

## Verification

End-to-end tested in us-west-2 against the branch:

| Configuration | Result |
|---|---|
| Template only, no licences on disk | ✓ stack reaches `CREATE_COMPLETE`, neo4j active, both plugins gracefully report `missing`/`invalid` with no errors, no regression |
| `deploy.py r8i.xlarge --mode Public` (no licence flags) | ✓ existing behaviour preserved (regression test) |
| `deploy.py r8i.2xlarge --mode Public --number-of-servers 1 --bloom-license-secret-id … --gds-license-secret-id …` | ✓ Bloom valid, GDS Enterprise (`isLicensed=TRUE`, `gdsEdition="Licensed"`) |
| `deploy.py r8i.xlarge --mode Public` (3-node default) `--bloom-license-secret-id` only | ✓ rolling install across 3 nodes; GDS branch correctly skipped |
| `deploy.py r8i.xlarge --mode Private --number-of-servers 1 --bloom-license-secret-id … --gds-license-secret-id …` | ✓ both Enterprise; bastion correctly filtered out by the `Role=neo4j-cluster-node` filter |

### Out of scope / observed but not addressed

- **`--tls` flow has a pre-existing bug** that is unrelated to this PR: `deploy.py` tries to read an SSM parameter `/neo4j-ee/<stack>/nlb-dns` that the template doesn't create. Reproducible on current `main`. This PR's `install_licenses` is positioned after the TLS phase so it cannot regress `--tls`; the licence install never runs when TLS fails. Worth a separate issue.
- **`test_neo4j/` doesn't exercise the licence path** today. `gds.version()` passes in Community mode, so existing tests would pass against a misconfigured deploy. The verification on a single instance via cypher-shell in this PR is a partial mitigation; a proper test_neo4j addition is follow-up work.

## Risk

- No new template parameters; no parameter removals
- No deletions in either commit
- New code paths are opt-in (CLI flags or `installGDS=true`)
- IAM policy is scoped to specific secret ARNs and attached to a stack-managed role (auto-deleted with the stack)
- No change to networking, NLB, security groups, existing IAM, or any pre-existing parameter behaviour

## Why now

I hit this preparing a customer workshop. Spent several hours debugging Bloom UI's "We couldn't find a license" message before realising both the JAR copy AND the config key were missing. GDS was even more concerning because `gds.version()` returns a value in Community mode too, so a smoke test passes against a non-Enterprise deploy. Easy to miss in silently-degraded customer environments.
